### PR TITLE
Allow other mods to send console messages and register commands

### DIFF
--- a/src/console.c
+++ b/src/console.c
@@ -743,10 +743,10 @@ void fn_vInitConsole( void )
 	FNT_fn_vFontInit();
 
 	fn_vInitVars();
+	fn_vInitCommands();
 
 	fn_vPrint(g_szVersion);
 	fn_vPrint("Type \"help\" for available commands");
-	fn_vInitCommands();
 
 	g_bIsInit = TRUE;
 }

--- a/src/console.c
+++ b/src/console.c
@@ -746,6 +746,7 @@ void fn_vInitConsole( void )
 
 	fn_vPrint(g_szVersion);
 	fn_vPrint("Type \"help\" for available commands");
+	fn_vInitCommands();
 
 	g_bIsInit = TRUE;
 }

--- a/src/console.h
+++ b/src/console.h
@@ -4,8 +4,6 @@
 
 #include "utils.h"
 
-#define LIBRARY_API __declspec(dllimport)
-
 
 /****************************************************************************
  * Main
@@ -90,8 +88,11 @@ typedef struct tdstCommand
 tdstCommand;
 
 
-extern tdstCommand g_a_stCommands[];
-extern int const g_lNbCommands;
+LIBRARY_API extern tdstCommand* g_a_stCommands;
+LIBRARY_API extern int g_lNbCommands;
+extern void fn_vInitCommands();
+LIBRARY_API extern void fn_vRegisterCommand( char* szName, tdfnCommand* p_stCommand );
+LIBRARY_API extern void fn_vRegisterCommandW( tdstCommand command );
 
 extern void *g_pvLastCommandData;
 

--- a/src/console.h
+++ b/src/console.h
@@ -89,9 +89,8 @@ tdstCommand;
 
 extern tdstCommand* g_a_stCommands;
 extern int g_lNbCommands;
-extern void fn_vInitCommands();
-extern void fn_vRegisterCommandW( tdstCommand command );
-R2CON_API extern void fn_vRegisterCommand( char* szName, tdfnCommand* p_stCommand );
+extern void fn_vInitCommands( void );
+R2CON_API extern void fn_vRegisterCommand( char *szName, tdfnCommand *p_stCommand );
 
 extern void *g_pvLastCommandData;
 

--- a/src/console.h
+++ b/src/console.h
@@ -4,6 +4,8 @@
 
 #include "utils.h"
 
+#define LIBRARY_API __declspec(dllimport)
+
 
 /****************************************************************************
  * Main
@@ -52,13 +54,13 @@ extern tdstLine g_a_stLines[C_NbLines];
 void fn_vEarlyInitConsole( void );
 void fn_vInitConsole( void );
 
-void fn_vPrintEx( char const *szString, unsigned char ucColor, char cPrefix );
-void fn_vPrintCFmt( unsigned char ucColor, char *szFmt, ... );
-void fn_vPrintC( unsigned char ucColor, char const *szString );
-void fn_vPrint( char const *szString );
+LIBRARY_API void fn_vPrintEx( char const *szString, unsigned char ucColor, char cPrefix );
+LIBRARY_API void fn_vPrintCFmt( unsigned char ucColor, char *szFmt, ... );
+LIBRARY_API void fn_vPrintC( unsigned char ucColor, char const *szString );
+LIBRARY_API void fn_vPrint( char const *szString );
 
-void fn_vResetScroll( void );
-void fn_vPasteAtCaret( char *szStr, int lStrLen );
+LIBRARY_API void fn_vResetScroll( void );
+LIBRARY_API void fn_vPasteAtCaret( char *szStr, int lStrLen );
 
 
 /****************************************************************************

--- a/src/console.h
+++ b/src/console.h
@@ -1,7 +1,6 @@
 ﻿#pragma once
 
 #include "framework.h"
-
 #include "utils.h"
 
 
@@ -52,13 +51,13 @@ extern tdstLine g_a_stLines[C_NbLines];
 void fn_vEarlyInitConsole( void );
 void fn_vInitConsole( void );
 
-LIBRARY_API void fn_vPrintEx( char const *szString, unsigned char ucColor, char cPrefix );
-LIBRARY_API void fn_vPrintCFmt( unsigned char ucColor, char *szFmt, ... );
-LIBRARY_API void fn_vPrintC( unsigned char ucColor, char const *szString );
-LIBRARY_API void fn_vPrint( char const *szString );
+R2CON_API void fn_vPrintEx( char const *szString, unsigned char ucColor, char cPrefix );
+R2CON_API void fn_vPrintCFmt( unsigned char ucColor, char *szFmt, ... );
+R2CON_API void fn_vPrintC( unsigned char ucColor, char const *szString );
+R2CON_API void fn_vPrint( char const *szString );
 
-LIBRARY_API void fn_vResetScroll( void );
-LIBRARY_API void fn_vPasteAtCaret( char *szStr, int lStrLen );
+void fn_vResetScroll( void );
+void fn_vPasteAtCaret( char *szStr, int lStrLen );
 
 
 /****************************************************************************
@@ -88,11 +87,11 @@ typedef struct tdstCommand
 tdstCommand;
 
 
-LIBRARY_API extern tdstCommand* g_a_stCommands;
-LIBRARY_API extern int g_lNbCommands;
+extern tdstCommand* g_a_stCommands;
+extern int g_lNbCommands;
 extern void fn_vInitCommands();
-LIBRARY_API extern void fn_vRegisterCommand( char* szName, tdfnCommand* p_stCommand );
-LIBRARY_API extern void fn_vRegisterCommandW( tdstCommand command );
+extern void fn_vRegisterCommandW( tdstCommand command );
+R2CON_API extern void fn_vRegisterCommand( char* szName, tdfnCommand* p_stCommand );
 
 extern void *g_pvLastCommandData;
 

--- a/src/framework.h
+++ b/src/framework.h
@@ -9,3 +9,10 @@
 #include <math.h>
 
 #include <ACP_Ray2.h>
+
+
+#ifdef R2CONSOLE_EXPORTS
+#define R2CON_API __declspec(dllexport)
+#else
+#define R2CON_API __declspec(dllimport)
+#endif

--- a/src/utils.h
+++ b/src/utils.h
@@ -2,27 +2,26 @@
 
 #include "framework.h"
 
-#define LIBRARY_API __declspec(dllimport)
-
 
 /****************************************************************************
 * Utils
 ****************************************************************************/
 
-LIBRARY_API int fn_lSplitArgs( char *szString, char ***p_d_szArgsOut );
-LIBRARY_API void fn_vToLower( char *szDst, char *szSrc );
-LIBRARY_API int fn_vCharCountReverse( char *Str, char Ch, int lMaxChars );
-LIBRARY_API int fn_vNotCharCountReverse( char *Str, char Ch, int lMaxChars );
+int fn_lSplitArgs( char *szString, char ***p_d_szArgsOut );
+int fn_vCharCountReverse( char *Str, char Ch, int lMaxChars );
+int fn_vNotCharCountReverse( char *Str, char Ch, int lMaxChars );
 
-LIBRARY_API BOOL fn_bParseBool( char *szArg, BOOL *p_bOut );
-LIBRARY_API BOOL fn_bParseInt( char *szArg, int *p_lOut );
-LIBRARY_API BOOL fn_bParseReal( char *szArg, MTH_tdxReal *p_xOut );
-LIBRARY_API int fn_lParseCoordinates( int lSize, char **d_szArgs, MTH_tdxReal *d_xOut );
+R2CON_API void fn_vToLower( char *szDst, char *szSrc );
 
-LIBRARY_API BOOL fn_bParsePtr( char *szArg, void **p_pOut );
-LIBRARY_API BOOL fn_bParseObjectRef( char *szArg, HIE_tdstSuperObject **p_pstOut );
+R2CON_API BOOL fn_bParseBool( char *szArg, BOOL *p_bOut );
+R2CON_API BOOL fn_bParseInt( char *szArg, int *p_lOut );
+R2CON_API BOOL fn_bParseReal( char *szArg, MTH_tdxReal *p_xOut );
+R2CON_API int fn_lParseCoordinates( int lSize, char **d_szArgs, MTH_tdxReal *d_xOut );
 
-LIBRARY_API void fn_vMouseCoordToPercent( MTH2D_tdstVector *p_stOut, LPARAM lParam, HWND hWnd );
+R2CON_API BOOL fn_bParsePtr( char *szArg, void **p_pOut );
+R2CON_API BOOL fn_bParseObjectRef( char *szArg, HIE_tdstSuperObject **p_pstOut );
+
+void fn_vMouseCoordToPercent( MTH2D_tdstVector *p_stOut, LPARAM lParam, HWND hWnd );
 
 /* widescreen stuff */
 BOOL fn_bInitWidescreenSupport( void );

--- a/src/utils.h
+++ b/src/utils.h
@@ -2,25 +2,27 @@
 
 #include "framework.h"
 
+#define LIBRARY_API __declspec(dllimport)
+
 
 /****************************************************************************
 * Utils
 ****************************************************************************/
 
-int fn_lSplitArgs( char *szString, char ***p_d_szArgsOut );
-void fn_vToLower( char *szDst, char *szSrc );
-int fn_vCharCountReverse( char *Str, char Ch, int lMaxChars );
-int fn_vNotCharCountReverse( char *Str, char Ch, int lMaxChars );
+LIBRARY_API int fn_lSplitArgs( char *szString, char ***p_d_szArgsOut );
+LIBRARY_API void fn_vToLower( char *szDst, char *szSrc );
+LIBRARY_API int fn_vCharCountReverse( char *Str, char Ch, int lMaxChars );
+LIBRARY_API int fn_vNotCharCountReverse( char *Str, char Ch, int lMaxChars );
 
-BOOL fn_bParseBool( char *szArg, BOOL *p_bOut );
-BOOL fn_bParseInt( char *szArg, int *p_lOut );
-BOOL fn_bParseReal( char *szArg, MTH_tdxReal *p_xOut );
-int fn_lParseCoordinates( int lSize, char **d_szArgs, MTH_tdxReal *d_xOut );
+LIBRARY_API BOOL fn_bParseBool( char *szArg, BOOL *p_bOut );
+LIBRARY_API BOOL fn_bParseInt( char *szArg, int *p_lOut );
+LIBRARY_API BOOL fn_bParseReal( char *szArg, MTH_tdxReal *p_xOut );
+LIBRARY_API int fn_lParseCoordinates( int lSize, char **d_szArgs, MTH_tdxReal *d_xOut );
 
-BOOL fn_bParsePtr( char *szArg, void **p_pOut );
-BOOL fn_bParseObjectRef( char *szArg, HIE_tdstSuperObject **p_pstOut );
+LIBRARY_API BOOL fn_bParsePtr( char *szArg, void **p_pOut );
+LIBRARY_API BOOL fn_bParseObjectRef( char *szArg, HIE_tdstSuperObject **p_pstOut );
 
-void fn_vMouseCoordToPercent( MTH2D_tdstVector *p_stOut, LPARAM lParam, HWND hWnd );
+LIBRARY_API void fn_vMouseCoordToPercent( MTH2D_tdstVector *p_stOut, LPARAM lParam, HWND hWnd );
 
 /* widescreen stuff */
 BOOL fn_bInitWidescreenSupport( void );


### PR DESCRIPTION
This implementation is probably far from optimal so feel free to request any changes to this you want me to make!

- Adds __declspec(dllimport) to most methods to allow other mods to call them and send messages to the console.
- Reworks the command array to allow registering new commands and move all built-in commands to an init function

I've tested these changes and all commands appear to function properly. Running the import functions from another mod also works fine as well as registering commands from another mod.

Code is a bit rough as I don't have that much C++ experience.