### PR TITLE
Add a secondary keybind to open the console for non-US keyboards

### DIFF
--- a/src/console.c
+++ b/src/console.c
@@ -783,7 +783,7 @@ void fn_vBackspaceCharAtCaret( void )
 
 BOOL fn_bProcessKey( DWORD dwKeyCode )
 {
-	if ( dwKeyCode == VK_OEM_3 )
+	if ( dwKeyCode == VK_OEM_3 || dwKeyCode == VK_F3 )
 	{
 		g_bTinyMode = GetKeyState(VK_SHIFT) & 0x8000 ? TRUE : FALSE;
 		fn_vShowConsole();

--- a/src/console.c
+++ b/src/console.c
@@ -783,7 +783,7 @@ void fn_vBackspaceCharAtCaret( void )
 
 BOOL fn_bProcessKey( DWORD dwKeyCode )
 {
-	if ( dwKeyCode == VK_OEM_3 || dwKeyCode == VK_F3 )
+	if ( dwKeyCode == VK_OEM_3 || dwKeyCode == VK_F12 )
 	{
 		g_bTinyMode = GetKeyState(VK_SHIFT) & 0x8000 ? TRUE : FALSE;
 		fn_vShowConsole();


### PR DESCRIPTION
I've shared this mod with various international people and I frequently got feedback that they could not find the console keybind as ~ gets remapped to different keys in international keyboards. So I suggest adding F3 as an secondary button as it's the same key between international keyboard layouts. It should not clip as the base-game uses F1 for Think and F8 for screenshot, so F3 should be available.